### PR TITLE
Reduce docker build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+.git
 demo.gif
 data/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+demo.gif
 data/


### PR DESCRIPTION
Building images in remote docker host (using `DOCKER_HOST=ssh://user@repo docker build`) sends the whole docker build context to the remote docker host. Ignoring demo.gif reduces the transfer size from ~17MB to 0.3MB.