### PR TITLE
CI pipeline - initial implementation

### DIFF
--- a/.iceci.yaml
+++ b/.iceci.yaml
@@ -1,0 +1,43 @@
+globals:
+  dockerSecret: dockerhub
+
+steps:
+- name: build-docker-image-frontend
+  runtimeProfile: nodejs
+  containerBuild:
+    user: mrupgrade
+    imageName: smart-social-distancing
+    dockerfilePath: frontend.Dockerfile
+    cache:
+      enable: true
+    tags:
+    - "{{ ICECI_GIT_TAG_OR_BRANCH }}-frontend"
+
+
+- name: build-docker-image-x86
+  containerBuild:
+    user: mrupgrade
+    imageName: smart-social-distancing
+    dockerfilePath: x86.Dockerfile
+    cache:
+      enable: true
+    tags:
+    - "{{ ICECI_GIT_TAG_OR_BRANCH }}-x86"
+    buildArgs:
+    - name: frontend_uri
+      value: "mrupgrade/smart-social-distancing:{{ ICECI_GIT_TAG_OR_BRANCH }}-frontend"
+
+
+- name: build-docker-image-jetson-nano
+  runtimeProfile: jetson
+  containerBuild:
+    user: mrupgrade
+    imageName: smart-social-distancing
+    dockerfilePath: jetson-nano.Dockerfile
+    cache:
+      enable: true
+    tags:
+    - "{{ ICECI_GIT_TAG_OR_BRANCH }}-jetson-nano"
+    buildArgs:
+    - name: frontend_uri
+      value: "mrupgrade/smart-social-distancing:{{ ICECI_GIT_TAG_OR_BRANCH }}-frontend"

--- a/.iceci.yaml
+++ b/.iceci.yaml
@@ -15,6 +15,7 @@ steps:
 
 
 - name: build-docker-image-x86
+  runtimeProfile: amd64
   containerBuild:
     user: mrupgrade
     imageName: smart-social-distancing

--- a/.iceci.yaml
+++ b/.iceci.yaml
@@ -5,7 +5,7 @@ steps:
 - name: build-docker-image-frontend
   runtimeProfile: nodejs
   containerBuild:
-    user: mrupgrade
+    user: neuralet
     imageName: smart-social-distancing
     dockerfilePath: frontend.Dockerfile
     tags:
@@ -15,24 +15,24 @@ steps:
 - name: build-docker-image-x86
   runtimeProfile: amd64
   containerBuild:
-    user: mrupgrade
+    user: neuralet
     imageName: smart-social-distancing
     dockerfilePath: x86.Dockerfile
     tags:
     - "{{ ICECI_GIT_TAG_OR_BRANCH }}-x86"
     buildArgs:
     - name: frontend_uri
-      value: "mrupgrade/smart-social-distancing:{{ ICECI_GIT_TAG_OR_BRANCH }}-frontend"
+      value: "neuralet/smart-social-distancing:{{ ICECI_GIT_TAG_OR_BRANCH }}-frontend"
 
 
 - name: build-docker-image-jetson-nano
   runtimeProfile: jetson
   containerBuild:
-    user: mrupgrade
+    user: neuralet
     imageName: smart-social-distancing
     dockerfilePath: jetson-nano.Dockerfile
     tags:
     - "{{ ICECI_GIT_TAG_OR_BRANCH }}-jetson-nano"
     buildArgs:
     - name: frontend_uri
-      value: "mrupgrade/smart-social-distancing:{{ ICECI_GIT_TAG_OR_BRANCH }}-frontend"
+      value: "neuralet/smart-social-distancing:{{ ICECI_GIT_TAG_OR_BRANCH }}-frontend"

--- a/.iceci.yaml
+++ b/.iceci.yaml
@@ -3,6 +3,8 @@ globals:
 
 steps:
 - name: build-docker-image-frontend
+  when:
+    event: ["commit", "tag", "pr"]
   runtimeProfile: nodejs
   containerBuild:
     user: neuralet
@@ -14,6 +16,8 @@ steps:
 
 - name: build-docker-image-x86
   runtimeProfile: amd64
+  when:
+    event: ["commit", "tag", "pr"]
   containerBuild:
     user: neuralet
     imageName: smart-social-distancing
@@ -27,6 +31,8 @@ steps:
 
 - name: build-docker-image-jetson-nano
   runtimeProfile: jetson
+  when:
+    event: ["commit", "tag", "pr"]
   containerBuild:
     user: neuralet
     imageName: smart-social-distancing

--- a/.iceci.yaml
+++ b/.iceci.yaml
@@ -8,8 +8,6 @@ steps:
     user: mrupgrade
     imageName: smart-social-distancing
     dockerfilePath: frontend.Dockerfile
-    cache:
-      enable: true
     tags:
     - "{{ ICECI_GIT_TAG_OR_BRANCH }}-frontend"
 
@@ -20,8 +18,6 @@ steps:
     user: mrupgrade
     imageName: smart-social-distancing
     dockerfilePath: x86.Dockerfile
-    cache:
-      enable: true
     tags:
     - "{{ ICECI_GIT_TAG_OR_BRANCH }}-x86"
     buildArgs:
@@ -35,8 +31,6 @@ steps:
     user: mrupgrade
     imageName: smart-social-distancing
     dockerfilePath: jetson-nano.Dockerfile
-    cache:
-      enable: true
     tags:
     - "{{ ICECI_GIT_TAG_OR_BRANCH }}-jetson-nano"
     buildArgs:

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -6,4 +6,4 @@ COPY frontend /frontend
 RUN yarn build
 
 FROM scratch
-COPY --from=builder /build /build
+COPY --from=builder /frontend/build /frontend/build

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -6,4 +6,4 @@ COPY frontend /frontend
 RUN yarn build
 
 FROM scratch
-COPY --from=builder /frontend/build /frontend/build
+COPY --from=builder /build /build

--- a/jetson-nano.Dockerfile
+++ b/jetson-nano.Dockerfile
@@ -1,3 +1,7 @@
+# Allow change the frontend path for testing things on branch
+ARG frontend_uri=neuralet/smart-social-distancing:latest-frontend
+FROM ${frontend_uri} as fe
+
 # docker can be installed on the dev board following these instructions:
 # https://docs.docker.com/install/linux/docker-ce/debian/#install-using-the-repository , step 4: arm64
 # 1) build: docker build -f jetson-nano.Dockerfile -t "neuralet/smart-social-distancing:latest-jetson-nano" .
@@ -99,6 +103,5 @@ CMD ["--config", "config-jetson.ini"]
 WORKDIR /repo
 EXPOSE 8000
 
-COPY --from=neuralet/smart-social-distancing:latest-frontend /frontend/build /srv/frontend
-
-COPY . /repo
+COPY --from=fe /build /srv/frontend
+COPY . /repo/

--- a/jetson-nano.Dockerfile
+++ b/jetson-nano.Dockerfile
@@ -103,5 +103,5 @@ CMD ["--config", "config-jetson.ini"]
 WORKDIR /repo
 EXPOSE 8000
 
-COPY --from=fe /build /srv/frontend
+COPY --from=fe /frontend/build /srv/frontend
 COPY . /repo/

--- a/x86.Dockerfile
+++ b/x86.Dockerfile
@@ -1,3 +1,7 @@
+# Allow change the frontend path for testing things on branch
+ARG frontend_uri=neuralet/smart-social-distancing:latest-frontend
+FROM ${frontend_uri} as fe
+
 FROM tensorflow/tensorflow:latest-py3
 
 # The `python3-opencv` package isn't built with gstreamer on Ubuntu. So we need to manually build opencv.
@@ -80,6 +84,6 @@ CMD ["--config", "config-x86.ini"]
 WORKDIR /repo
 EXPOSE 8000
 
-COPY --from=neuralet/smart-social-distancing:latest-frontend /frontend/build /srv/frontend
+COPY --from=fe /build /srv/frontend
 
 COPY . /repo

--- a/x86.Dockerfile
+++ b/x86.Dockerfile
@@ -84,6 +84,6 @@ CMD ["--config", "config-x86.ini"]
 WORKDIR /repo
 EXPOSE 8000
 
-COPY --from=fe /build /srv/frontend
+COPY --from=fe /frontend/build /srv/frontend
 
 COPY . /repo


### PR DESCRIPTION
This is a simple pipeline for building frontend, x86 and Jetson Nano docker images. 

The images will be tagged with prefixes for 
- branch name for commit
- tag name for tag
- pr number in format pr-<number> for pull requests

After merging this PR I will enable the repository on the CI and then the build should run on every commit/pr/rag
Build result will be posted in the "ci" channel on slack. 