### PR TITLE
Fix: Send empty reports when there is no data for a camera instead of 404

### DIFF
--- a/api/reports.py
+++ b/api/reports.py
@@ -79,13 +79,6 @@ def validate_existence(camera_id):
     dir_path = os.path.join(os.getenv('LogDirectory'), camera_id, "objects_log")
     if not os.path.exists(dir_path):
         raise HTTPException(status_code=404, detail=f'Camera with id "{camera_id}" does not exist')
-    if not os.path.exists(os.path.join(dir_path, 'report.csv')):
-        raise HTTPException(status_code=404, detail=f'Data has not been yet gathered for camera with id "{camera_id}"')
-
-def validate_existence_of_any_report():
-    reports = list(Path(os.path.join(os.getenv('LogDirectory'))).rglob('report.csv'))
-    if not reports:
-        raise HTTPException(status_code=404, detail='There are no reports for any camera')
 
 @reports_api.get("/{camera_id}/hourly", response_model=HourlyReport)
 def get_hourly_report(camera_id,
@@ -151,7 +144,6 @@ def get_average_violations(camera_id):
 
 @reports_api.get('/camera_with_most_violations')
 def get_camera_with_most_violations():
-    validate_existence_of_any_report()
     return {
         'cam_id': reports.camera_with_most_violations()
     }

--- a/config-x86.ini
+++ b/config-x86.ini
@@ -11,44 +11,33 @@ QueueAuthKey = shibalba
 Resolution = 640,480
 Encoder = videoconvert ! video/x-raw,format=I420 ! x264enc speed-preset=ultrafast
 MaxProcesses = 1
-; Screenshot time is measured in minutes (if period <= 0 then no screenshots are uploaded)
 ScreenshotPeriod = 0
 ScreenshotS3Bucket = my-screenshot-bucket
-; WIP https://github.com/neuralet/neuralet/issues/91
-;Encoder: videoconvert ! vaapih264enc
 DashboardURL = http://0.0.0.0:8000
 ScreenshotsDirectory = /repo/data/processor/static/screenshots
 CalibrationFile = /repo/data/homography_matrix/h_inverse.txt
 
 [Source_0]
 VideoPath = /repo/data/softbio_vid.mp4
-Tags = area1
-Name = Garden-Camera
-Id = default
-Emails =
-NotifyEveryMinutes = 0
-ViolationThreshold = 60
-
+Tags = 
+Name = Kitchen
+Id = 0
+Emails = renzo@xmartlabs.com
+NotifyEveryMinutes = 60
+ViolationThreshold = 15
 
 [Detector]
-; Supported devices: Jetson , EdgeTPU, Dummy, x86
 Device = x86
-; Supported models: mobilenet_ssd_v2 and openpifpaf
 Name = mobilenet_ssd_v2
-;ImageSize should be 3 numbers seperated by commas, no spaces: 300,300,3 (for better accuracy use higher resolution when
-; using openpifpaf
 ImageSize = 300,300,3
-ModelPath =
+ModelPath = 
 ClassID = 1
 MinScore = 0.25
 
 [PostProcessor]
 MaxTrackFrame = 5
 NMSThreshold = 0.98
-; distance threshold for smart distancing in (cm)
 DistThreshold = 150
-; distance measurement method, CalibratedDistance: calculate the distance with 3-d transformed points, note that by choosing this method you should specify the inverse calibration matrix of your environment.
-;CenterPointsDistance: compare center of pedestrian boxes together, FourCornerPointsDistance: compare four corresponding points of pedestrian boxes and get the minimum of them.
 DistMethod = CenterPointsDistance
 Anonymize = true
 
@@ -58,3 +47,4 @@ TimeInterval = 0.5
 LogDirectory = /repo/data/processor/static/data
 EnableReports = no
 HeatmapResolution = 150,150
+

--- a/config-x86.ini
+++ b/config-x86.ini
@@ -11,33 +11,44 @@ QueueAuthKey = shibalba
 Resolution = 640,480
 Encoder = videoconvert ! video/x-raw,format=I420 ! x264enc speed-preset=ultrafast
 MaxProcesses = 1
+; Screenshot time is measured in minutes (if period <= 0 then no screenshots are uploaded)
 ScreenshotPeriod = 0
 ScreenshotS3Bucket = my-screenshot-bucket
+; WIP https://github.com/neuralet/neuralet/issues/91
+;Encoder: videoconvert ! vaapih264enc
 DashboardURL = http://0.0.0.0:8000
 ScreenshotsDirectory = /repo/data/processor/static/screenshots
 CalibrationFile = /repo/data/homography_matrix/h_inverse.txt
 
 [Source_0]
 VideoPath = /repo/data/softbio_vid.mp4
-Tags = 
-Name = Kitchen
-Id = 0
-Emails = renzo@xmartlabs.com
-NotifyEveryMinutes = 60
-ViolationThreshold = 15
+Tags = area1
+Name = Garden-Camera
+Id = default
+Emails =
+NotifyEveryMinutes = 0
+ViolationThreshold = 60
+
 
 [Detector]
+; Supported devices: Jetson , EdgeTPU, Dummy, x86
 Device = x86
+; Supported models: mobilenet_ssd_v2 and openpifpaf
 Name = mobilenet_ssd_v2
+;ImageSize should be 3 numbers seperated by commas, no spaces: 300,300,3 (for better accuracy use higher resolution when
+; using openpifpaf
 ImageSize = 300,300,3
-ModelPath = 
+ModelPath =
 ClassID = 1
 MinScore = 0.25
 
 [PostProcessor]
 MaxTrackFrame = 5
 NMSThreshold = 0.98
+; distance threshold for smart distancing in (cm)
 DistThreshold = 150
+; distance measurement method, CalibratedDistance: calculate the distance with 3-d transformed points, note that by choosing this method you should specify the inverse calibration matrix of your environment.
+;CenterPointsDistance: compare center of pedestrian boxes together, FourCornerPointsDistance: compare four corresponding points of pedestrian boxes and get the minimum of them.
 DistMethod = CenterPointsDistance
 Anonymize = true
 
@@ -47,4 +58,3 @@ TimeInterval = 0.5
 LogDirectory = /repo/data/processor/static/data
 EnableReports = no
 HeatmapResolution = 150,150
-

--- a/libs/utils/reports.py
+++ b/libs/utils/reports.py
@@ -222,9 +222,7 @@ class ReportsService:
 
     def camera_with_most_violations(self):
         log_dir = os.getenv('LogDirectory')
-        cameras = os.listdir(log_dir)
-        if '.keep' in cameras:
-            cameras.remove('.keep')
+        cameras = [directory for directory in os.listdir(log_dir) if os.path.isdir(os.path.join(log_dir, directory))]
         cameras_violations = {}
         for camera_id in cameras:
             file_path = os.path.join(log_dir, camera_id, "objects_log", "report.csv")

--- a/libs/utils/reports.py
+++ b/libs/utils/reports.py
@@ -45,18 +45,20 @@ class ReportsService:
         hours = list(range(0, 24))
         detected_objects = np.zeros(24)
         violating_objects = np.zeros(24)
-        iters = 0
-        for date in date_range:
-            file_path = os.path.join(dir_path, f"report_{date.strftime('%Y-%m-%d')}.csv")
-            if os.path.exists(file_path):
-                iters += 1
-                df = pd.read_csv(file_path).drop(['Number'], axis=1)
-                detected_objects = detected_objects + df['DetectedObjects'].to_numpy()
-                violating_objects = violating_objects + df['ViolatingObjects'].to_numpy()
 
-        if iters != 0:
-            detected_objects = detected_objects/iters
-            violating_objects = violating_objects/iters
+        if os.path.exists(os.path.join(dir_path, 'report.csv')):
+            iters = 0
+            for date in date_range:
+                file_path = os.path.join(dir_path, f"report_{date.strftime('%Y-%m-%d')}.csv")
+                if os.path.exists(file_path):
+                    iters += 1
+                    df = pd.read_csv(file_path).drop(['Number'], axis=1)
+                    detected_objects = detected_objects + df['DetectedObjects'].to_numpy()
+                    violating_objects = violating_objects + df['ViolatingObjects'].to_numpy()
+
+            if iters != 0:
+                detected_objects = detected_objects/iters
+                violating_objects = violating_objects/iters
 
         report = {
             'hours': hours,
@@ -85,17 +87,20 @@ class ReportsService:
 
         log_dir = os.getenv('LogDirectory')
         file_path = os.path.join(log_dir, camera_id, "objects_log", "report.csv")
-        df = pd.read_csv(file_path).drop(['Number'], axis=1)
-        df['Date'] = pd.to_datetime(df['Date'], format='%Y-%m-%d')
+        if os.path.exists(file_path):
+            df = pd.read_csv(file_path).drop(['Number'], axis=1)
+            df['Date'] = pd.to_datetime(df['Date'], format='%Y-%m-%d')
 
-        mask = (df['Date'] >= pd.to_datetime(from_date)) & (df['Date'] <= pd.to_datetime(to_date))
-        filtered_reports = df.loc[mask]
-        filtered_reports['Date'] = filtered_reports['Date'].apply(lambda x: x.strftime('%Y-%m-%d'))
-        filtered_reports = filtered_reports.set_index('Date').T
+            mask = (df['Date'] >= pd.to_datetime(from_date)) & (df['Date'] <= pd.to_datetime(to_date))
+            filtered_reports = df.loc[mask]
+            filtered_reports['Date'] = filtered_reports['Date'].apply(lambda x: x.strftime('%Y-%m-%d'))
+            filtered_reports = filtered_reports.set_index('Date').T
 
-        # Dictionary union. Favour the actual results over the initialized ones
-        merged_report = dict(base_results, **filtered_reports.to_dict())
-        merged_report = {datetime.strptime(key, '%Y-%m-%d'): merged_report[key] for key in merged_report}
+            # Dictionary union. Favour the actual results over the initialized ones
+            merged_report = dict(base_results, **filtered_reports.to_dict())
+            merged_report = {datetime.strptime(key, '%Y-%m-%d'): merged_report[key] for key in merged_report}
+        else:
+            merged_report = {datetime.strptime(key, '%Y-%m-%d'): base_results[key] for key in base_results}
 
         dates = []
         detected_objects = []
@@ -195,6 +200,9 @@ class ReportsService:
     def peak_hour_violations(self, camera_id):
         log_dir = os.getenv('LogDirectory')
         dir_path = os.path.join(log_dir, camera_id, "objects_log")
+        if not os.path.exists(os.path.join(dir_path, 'report.csv')):
+            return 0
+
         files = glob.glob(f"{dir_path}/report_*.csv")
         violating_objects = np.zeros(24)
         for file_path in files:
@@ -207,17 +215,23 @@ class ReportsService:
     def average_violations(self, camera_id):
         log_dir = os.getenv('LogDirectory')
         file_path = os.path.join(log_dir, camera_id, "objects_log", "report.csv")
+        if not os.path.exists(file_path):
+            return 0.0
         df = pd.read_csv(file_path).drop(['Number'], axis=1)
         return round(df['ViolatingObjects'].mean(), 1)
 
     def camera_with_most_violations(self):
         log_dir = os.getenv('LogDirectory')
         cameras = os.listdir(log_dir)
+        if '.keep' in cameras:
+            cameras.remove('.keep')
         cameras_violations = {}
         for camera_id in cameras:
             file_path = os.path.join(log_dir, camera_id, "objects_log", "report.csv")
             if os.path.exists(file_path):
                 df = pd.read_csv(file_path).drop(['Number'], axis=1)
                 cameras_violations[camera_id] = df['ViolatingObjects'].mean()
+            else:
+                cameras_violations[camera_id] = 0
 
         return max(cameras_violations, key=cameras_violations.get)


### PR DESCRIPTION
Previously the reports endpoints checked whether reports for a camera were generated or not.

Now a camera without reports is considered the same as having no detections/violations and returns an empty report for said dates expected.