### PR TITLE
Autogenereted Ids for Cameras

### DIFF
--- a/api/models/base.py
+++ b/api/models/base.py
@@ -14,7 +14,7 @@ class SnakeModel(BaseModel):
 
 
 class EntityConfigDTO(SnakeModel):
-    id: Optional[str] = Field(example='SABORR')
+    id: Optional[str] = Field(example='0')
     name: str = Field(example='Kitchen')
 
 

--- a/api/models/base.py
+++ b/api/models/base.py
@@ -14,7 +14,7 @@ class SnakeModel(BaseModel):
 
 
 class EntityConfigDTO(SnakeModel):
-    id: str = Field(example='0')
+    id: Optional[str] = Field(example='SABORR')
     name: str = Field(example='Kitchen')
 
 

--- a/api/routers/cameras.py
+++ b/api/routers/cameras.py
@@ -143,6 +143,35 @@ async def get_camera(camera_id: str):
     return camera
 
 
+def get_first_unused_id(arr):
+    if not arr:
+        return 0
+
+    ids_numbers = []
+    for value in arr:
+        try:
+            number = int(value)
+            if number >= 0:
+                ids_numbers.append(number)
+        except ValueError:
+            pass
+
+    if not ids_numbers:
+        return 0
+
+    ids_numbers.sort()
+
+    result = 0
+    for i in range(0, ids_numbers[len(ids_numbers)-1]+1):
+        if ids_numbers[i] != i:
+            result = i
+            break
+    else:
+        result = ids_numbers[len(ids_numbers)-1] + 1
+
+    return result
+
+
 @cameras_router.post("", response_model=CameraDTO, status_code=status.HTTP_201_CREATED)
 async def create_camera(new_camera: CameraDTO, reboot_processor: Optional[bool] = True):
     """
@@ -151,7 +180,11 @@ async def create_camera(new_camera: CameraDTO, reboot_processor: Optional[bool] 
     config_dict = extract_config()
     cameras_name = [x for x in config_dict.keys() if x.startswith("Source_")]
     cameras = [map_camera(x, config_dict) for x in cameras_name]
-    if new_camera.id in [camera["id"] for camera in cameras]:
+
+    if new_camera.id is None:
+        ids = [camera["id"] for camera in cameras]
+        new_camera.id = get_first_unused_id(ids)
+    elif new_camera.id in [camera["id"] for camera in cameras]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=bad_request_serializer("Camera already exists", error_type="config duplicated camera")

--- a/api/routers/cameras.py
+++ b/api/routers/cameras.py
@@ -158,7 +158,7 @@ def get_first_unused_id(cameras_ids):
     for i in range(0, ids_numbers[len(ids_numbers)-1]+1):
         if ids_numbers[i] != i:
             return i
-    return ids_numbers[len(ids_numbers)-1] + 1
+    return ids_numbers[-1] + 1
 
 
 @cameras_router.post("", response_model=CameraDTO, status_code=status.HTTP_201_CREATED)

--- a/api/routers/cameras.py
+++ b/api/routers/cameras.py
@@ -155,15 +155,10 @@ def get_first_unused_id(cameras_ids):
         return 0
 
     ids_numbers.sort()
-    result = 0
     for i in range(0, ids_numbers[len(ids_numbers)-1]+1):
         if ids_numbers[i] != i:
-            result = i
-            break
-    else:
-        result = ids_numbers[len(ids_numbers)-1] + 1
-
-    return result
+            return i
+    return ids_numbers[len(ids_numbers)-1] + 1
 
 
 @cameras_router.post("", response_model=CameraDTO, status_code=status.HTTP_201_CREATED)

--- a/api/routers/cameras.py
+++ b/api/routers/cameras.py
@@ -2,6 +2,7 @@ import base64
 import cv2 as cv
 import logging
 import os
+import re
 
 from fastapi import APIRouter, status
 from starlette.exceptions import HTTPException
@@ -143,24 +144,17 @@ async def get_camera(camera_id: str):
     return camera
 
 
-def get_first_unused_id(arr):
-    if not arr:
+def get_first_unused_id(cameras_ids):
+    if not cameras_ids:
         return 0
 
-    ids_numbers = []
-    for value in arr:
-        try:
-            number = int(value)
-            if number >= 0:
-                ids_numbers.append(number)
-        except ValueError:
-            pass
+    is_a_number = re.compile("^[0-9]+$")
+    ids_numbers = [int(value) for value in cameras_ids if is_a_number.match(value)]
 
     if not ids_numbers:
         return 0
 
     ids_numbers.sort()
-
     result = 0
     for i in range(0, ids_numbers[len(ids_numbers)-1]+1):
         if ids_numbers[i] != i:


### PR DESCRIPTION
In this branch, the way camera IDs are generated has been changed.
Now the ID field is no longer required. If it is passed, the endpoint will save it as usual. However, if not, the endpoint will look up all other numeric ID and assign the corresponding ID to the new camera.